### PR TITLE
fix: AdminTable row select navigates only to users collection.

### DIFF
--- a/packages/module/src/runtime/app/components/Admin/AdminTable.vue
+++ b/packages/module/src/runtime/app/components/Admin/AdminTable.vue
@@ -94,13 +94,7 @@ watch(page, value => emit('update:page', value))
         :columns="columns"
         :data="props.rows"
         :class="props.tableClass"
-        @select="(row) => navigateTo({
-          name: 'admin-collections-table-id',
-          params: {
-            table: props.table,
-            id: row.original.id,
-          },
-        })"
+        @select="(row) => emit('on-click', row.original.id)"
       />
       <div class="flex justify-end mt-2">
         <UPagination

--- a/packages/module/src/runtime/app/components/Admin/AdminTable.vue
+++ b/packages/module/src/runtime/app/components/Admin/AdminTable.vue
@@ -22,6 +22,7 @@ type TableColumnDef<TData = unknown> = {
 type TableProps<T> = {
   visibleProps: string[]
   rows: T[]
+  table: string
   tableClass?: string
   total?: number
   pageCount?: number
@@ -96,7 +97,7 @@ watch(page, value => emit('update:page', value))
         @select="(row) => navigateTo({
           name: 'admin-collections-table-id',
           params: {
-            table: 'users',
+            table: props.table,
             id: row.original.id,
           },
         })"


### PR DESCRIPTION
## Bug Description

After creating a collection with the cli, and running the playground it is not possible to navigate to a created row.
The AdminTable component had the `users` collection hardcoded.

<img width="957" height="485" alt="Screenshot 2025-09-28 at 21 18 55" src="https://github.com/user-attachments/assets/b4871381-4604-4815-9904-eb5d71f15b53" />

## Fix Description
Instead of navigating, we emit the on click event that is correctly handled in all uses of `AdminTable` 